### PR TITLE
build vignettes, pkgdown

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           devtools::build_site(preview=F, new_process=F)
-          devtools::build_manual(path="dist")
+          devtools::build(vignettes=T, manual=F, path="dist")
         shell: Rscript {0}
       - name: Upload Interactive Coverage Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,11 +33,12 @@ jobs:
       - name: Check Package
         uses: r-lib/actions/check-r-package@v2
       - name: Test Coverage
-        run: Rscript scripts/coverage_html.R
+        run: Rscript scripts/coverage.R
       - name: Build documentation
         if: runner.os == 'Linux'
         run: |
           devtools::build_site(preview=F, new_process=F)
+          devtools::build_manual(path="dist")
         shell: Rscript {0}
       - name: Upload Interactive Coverage Report
         uses: actions/upload-artifact@v4
@@ -45,6 +46,7 @@ jobs:
         with:
           name: rscaffold
           path: |
-            coverage_html
+            coverage
             docs
+            dist
           retention-days: 90

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check Package
         uses: r-lib/actions/check-r-package@v2
       - name: Test Coverage
-        shell: Rscript scripts/coverage_html.R
+        run: Rscript scripts/coverage_html.R
       - name: Upload Interactive Coverage Report
         uses: actions/upload-artifact@v4
         if: runner.os == 'Linux'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true
+      - uses: r-lib/actions/setup-tinytex@v2
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck, any::covr, any::DT, any::devtools

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,54 +27,11 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck, any::covr, any::DT, any::devtools
-      - name: check package
+      - name: Check Package
         uses: r-lib/actions/check-r-package@v2
-      - name: Test coverage
-        run: |
-          coverage_output <- covr::package_coverage(
-            quiet = FALSE,
-            clean = FALSE,
-          )
-          covr::report(
-            coverage_output,
-            file = 'coverage_html/index.html',
-            browse =  FALSE
-          )
-          markdown <- function(x, group = c("filename", "functions"), by = "line", ...) {
-            if (length(x) == 0) {
-              return(invisible(x))
-            }
-            group <- match.arg(group)
-            df <- covr::tally_coverage(x, by = by)
-
-            if (!NROW(df)) {
-              return(invisible(x))
-            }
-            percents <- tapply(
-              df$value, df[[group]],
-              FUN = function(x) (sum(x > 0) / length(x)) * 100
-            )
-            overall_percentage <- covr::percent_coverage(df, by = by)
-            paste0(
-              "|file|percents|\n|----|----|\n",
-              paste0("|Overall|", format(overall_percentage, digits = 4), "%|\n"),
-              paste0("|", names(percents), "|", format(percents, digits = 4), "%|", collapse = "\n"),
-              "\n"
-            )
-          }
-          coverage_output_markdown <- markdown(coverage_output)
-          # log output to $GITHUB_STEP_SUMMARY
-          gh <- "# Coverage Summary Report"
-          gh <- paste(gh, coverage_output_markdown, sep="\n")
-          gh <- paste(gh, "View the interactive report by downloading the artifact.", sep="\n")
-          # Get system information
-          sys_info <- Sys.info()
-          is_linux <- sys_info["sysname"] == "Linux"
-          if (is_linux) {
-            write(gh, file=Sys.getenv("GITHUB_STEP_SUMMARY"))
-          }
-        shell: Rscript {0}
-      - name: upload coverage interactive report
+      - name: Test Coverage
+        shell: Rscript scripts/coverage_html.R
+      - name: Upload Interactive Coverage Report
         uses: actions/upload-artifact@v4
         if: runner.os == 'Linux'
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           devtools::build_site(preview=F, new_process=F)
-          devtools::build(vignettes=T, manual=F, path="dist")
+          devtools::build(vignettes=T, manual=T, path="dist")
         shell: Rscript {0}
       - name: Upload Interactive Coverage Report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '30 3 1 */1 *'  # At 03:30 on the 1st of every month
+  workflow_dispatch:
 
 jobs:
   R-CMD-check:
@@ -31,10 +34,17 @@ jobs:
         uses: r-lib/actions/check-r-package@v2
       - name: Test Coverage
         run: Rscript scripts/coverage_html.R
+      - name: Build documentation
+        if: runner.os == 'Linux'
+        run: |
+          devtools::build_site(preview=F, new_process=F)
+        shell: Rscript {0}
       - name: Upload Interactive Coverage Report
         uses: actions/upload-artifact@v4
         if: runner.os == 'Linux'
         with:
-          name: rscaffold-coverage
-          path: coverage_html
-          retention-days: 7
+          name: rscaffold
+          path: |
+            coverage_html
+            docs
+          retention-days: 90

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,8 +38,8 @@ jobs:
       - name: Build documentation
         if: runner.os == 'Linux'
         run: |
-          devtools::build_site(preview=F, new_process=F)
-          devtools::build(vignettes=T, manual=T, path="dist")
+          devtools::build_site(preview = F, new_process = F)
+          devtools::build_manual(pkg = ".", path = "dist")
         shell: Rscript {0}
       - name: Upload Interactive Coverage Report
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@
 
 coverage_html
 /doc/
+/dist/
 /Meta/

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 *.o
 *.dll
 
-coverage_html
+/coverage
 /dist/*.tar.gz
 /Meta/
 /doc

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 *.dll
 
 coverage_html
-/doc/
-/dist/
+/dist/*.tar.gz
 /Meta/
+/doc
+/docs

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,10 @@
 .Rproj.user
 .Rbuildignore
 
+*.so
+*.o
+*.dll
+
 coverage_html
+/doc/
+/Meta/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,10 +7,10 @@ Authors@R:
         comment = c(ORCID = "0000-0002-5233-8092")
     )
 Description: An opinionated starter template for building an R package.
-License: MIT
+License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Suggests:
     knitr,
     rmarkdown,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,6 +7,7 @@ Authors@R:
         comment = c(ORCID = "0000-0002-5233-8092")
     )
 Description: An opinionated starter template for building an R package.
+URL: https://github.com/shapiromatron/rscaffold/
 License: MIT + file LICENSE
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
@@ -19,4 +20,6 @@ Config/Needs/dev:
     devtools,
     testthat,
     covr
+Config/Needs/website:
+    r-lib/pkgdown
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,11 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Suggests:
+    knitr,
+    rmarkdown,
     testthat
 Config/Needs/dev:
     devtools,
     testthat,
     covr
+VignetteBuilder: knitr

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,2 @@
-Copyright 2024 Andy Shapiro
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+YEAR: 2024
+COPYRIGHT HOLDER: Andy Shapiro

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright 2024 Andy Shapiro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,4 +3,4 @@
 export(addition)
 export(square)
 export(subtraction)
-useDynLib(rscaffold)
+useDynLib(rscaffold, .registration = TRUE)

--- a/R/hello.R
+++ b/R/hello.R
@@ -28,7 +28,7 @@ subtraction <- function(a, b) {
 #'
 #' @param x The parameter to square
 #' @return the result
-#' @useDynLib rscaffold
+#' @useDynLib rscaffold, .registration = TRUE
 #' @export
 square <- function(x) {
   result <- .C("square", as.double(x), "rscaffold.so")

--- a/README.md
+++ b/README.md
@@ -13,5 +13,5 @@ R -e "devtools::install()"
 R -e "devtools::test()"
 
 # generate coverage report
-R -e "covr::report(file='coverage_html/index.html')"
+R -e "covr::report(file='coverage/index.html')"
 ```

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,5 @@
+url: shapiromatron.github.io/rscaffold/
+template:
+  bootstrap: 5
+  light-switch: true
+  bootswatch: flatly

--- a/scripts/coverage.R
+++ b/scripts/coverage.R
@@ -1,13 +1,3 @@
-coverage_output <- covr::package_coverage(
-    quiet = FALSE,
-    clean = FALSE,
-)
-covr::report(
-    coverage_output,
-    file = 'coverage_html/index.html',
-    browse =  FALSE
-)
-
 markdown <- function(x, group = c("filename", "functions"), by = "line", ...) {
     if (length(x) == 0) {
         return(invisible(x))
@@ -29,15 +19,21 @@ markdown <- function(x, group = c("filename", "functions"), by = "line", ...) {
         paste0("|", names(percents), "|", format(percents, digits = 4), "%|", collapse = "\n"),
         "\n"
     )
-    }
-    coverage_output_markdown <- markdown(coverage_output)
-    # log output to $GITHUB_STEP_SUMMARY
-    gh <- "# Coverage Summary Report"
-    gh <- paste(gh, coverage_output_markdown, sep="\n")
-    gh <- paste(gh, "View the interactive report by downloading the artifact.", sep="\n")
-    # Get system information
-    sys_info <- Sys.info()
-    is_linux <- sys_info["sysname"] == "Linux"
-    if (is_linux) {
-    write(gh, file=Sys.getenv("GITHUB_STEP_SUMMARY"))
+}
+
+coverage_output <- covr::package_coverage(quiet = FALSE, clean = FALSE)
+covr::report(coverage_output, file = 'coverage/index.html', browse =  FALSE)
+
+# log output to $GITHUB_STEP_SUMMARY
+is_linux <- Sys.info()["sysname"] == "Linux"
+if (is_linux) {
+    write(
+        paste(
+            "# Coverage Summary Report",
+            markdown(coverage_output),
+            "View the interactive report by downloading the artifact.",
+            sep="\n"
+        ),
+        file=Sys.getenv("GITHUB_STEP_SUMMARY")
+    )
 }

--- a/scripts/coverage_html.R
+++ b/scripts/coverage_html.R
@@ -1,0 +1,43 @@
+coverage_output <- covr::package_coverage(
+    quiet = FALSE,
+    clean = FALSE,
+)
+covr::report(
+    coverage_output,
+    file = 'coverage_html/index.html',
+    browse =  FALSE
+)
+
+markdown <- function(x, group = c("filename", "functions"), by = "line", ...) {
+    if (length(x) == 0) {
+        return(invisible(x))
+    }
+    group <- match.arg(group)
+    df <- covr::tally_coverage(x, by = by)
+
+    if (!NROW(df)) {
+        return(invisible(x))
+    }
+    percents <- tapply(
+        df$value, df[[group]],
+        FUN = function(x) (sum(x > 0) / length(x)) * 100
+    )
+    overall_percentage <- covr::percent_coverage(df, by = by)
+    paste0(
+        "|file|percents|\n|----|----|\n",
+        paste0("|Overall|", format(overall_percentage, digits = 4), "%|\n"),
+        paste0("|", names(percents), "|", format(percents, digits = 4), "%|", collapse = "\n"),
+        "\n"
+    )
+    }
+    coverage_output_markdown <- markdown(coverage_output)
+    # log output to $GITHUB_STEP_SUMMARY
+    gh <- "# Coverage Summary Report"
+    gh <- paste(gh, coverage_output_markdown, sep="\n")
+    gh <- paste(gh, "View the interactive report by downloading the artifact.", sep="\n")
+    # Get system information
+    sys_info <- Sys.info()
+    is_linux <- sys_info["sysname"] == "Linux"
+    if (is_linux) {
+    write(gh, file=Sys.getenv("GITHUB_STEP_SUMMARY"))
+}

--- a/vignettes/demo.Rmd
+++ b/vignettes/demo.Rmd
@@ -1,6 +1,6 @@
 ---
 title: "Demo"
-author: "CatReg Development Team"
+author: "RScaffold Development Team"
 date: "`r Sys.Date()`"
 output: html_vignette
 vignette: >

--- a/vignettes/demo.Rmd
+++ b/vignettes/demo.Rmd
@@ -1,0 +1,21 @@
+---
+title: "Demo"
+author: "CatReg Development Team"
+date: "`r Sys.Date()`"
+output: html_vignette
+vignette: >
+  %\VignetteIndexEntry{Demo}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(echo = TRUE, warning = FALSE, collapse = TRUE, comment = "#>")
+```
+
+Build an R vignette!
+
+```{r}
+paste("Hello world!")
+```
+


### PR DESCRIPTION
- Add a vignette
- Configure pkgdown documentation
- Minor updates to reduce warnings in `devtools::check()`
- Updates to github actions
    - make workflow run monthly and add a manual dispatch option
    - move markdown coverage text to a separate file instead of the workflow
    - build pkgdown site 
    - build PDF manual
    - add pkgdown site and PDF manual to downloadable artifact
